### PR TITLE
Put version number on index.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -100,5 +100,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <id>Update Site Page Version</id>
+            <phase>site</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <replace dir="${project.build.directory}/site" encoding="UTF-8">
+                  <replacefilter token="@project.version@" value="${project.version}" />
+                </replace>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -43,7 +43,7 @@
   <dependency>
     <groupId>org.mybatis.caches</groupId>
     <artifactId>mybatis-ehcache</artifactId>
-    <version>x.x.x</version>
+    <version>@project.version@</version>
   </dependency>
   ...
 </dependencies>]]></source>


### PR DESCRIPTION
While not the best solution in the world, used maven antrun to replace
version number token on index.xml therefore having site generate with
current version number for dependency.

Also, fixed redirect for maven pom xsd.

Site page index.html will then show this...

<dependencies>
  ...
  <dependency>
    <groupId>org.mybatis.caches</groupId>
    <artifactId>mybatis-ehcache</artifactId>
    <version>1.0.4-SNAPSHOT</version>
  </dependency>
  ...
</dependencies>
