### PR TITLE
Sonar Suggested Fixes - Comment unimplemented methods

### DIFF
--- a/src/main/java/org/mybatis/caches/ehcache/DummyReadWriteLock.java
+++ b/src/main/java/org/mybatis/caches/ehcache/DummyReadWriteLock.java
@@ -38,9 +38,11 @@ class DummyReadWriteLock implements ReadWriteLock {
     static class DummyLock implements Lock {
 
         public void lock() {
+            // Not implemented
         }
 
         public void lockInterruptibly() throws InterruptedException {
+            // Not implemented
         }
 
         public boolean tryLock() {
@@ -52,6 +54,7 @@ class DummyReadWriteLock implements ReadWriteLock {
         }
 
         public void unlock() {
+           // Not implemented
         }
 
         public Condition newCondition() {


### PR DESCRIPTION
Sonar with default settings complains about empty undefined methods.
Added comment 'Not implemented' under the three at issue.  Ehcache-cache module now shows completely clean in sonar.
