### PR TITLE
Updated POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>21</version>
+    <version>22-SNAPSHOT</version>
   </parent>
 
   <groupId>org.mybatis.caches</groupId>
@@ -28,7 +29,7 @@
   <version>1.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>MyBatis Caches :: Ehcache</name>
+  <name>mybatis-ehcache</name>
   <description>Ehcache support for MyBatis Cache</description>
   <url>http://www.mybatis.org/caches/ehcache/</url>
 
@@ -55,7 +56,7 @@
 
   <properties>
     <findbugs.onlyAnalyze>org.mybatis.caches.ehcache.*</findbugs.onlyAnalyze>
-    <clirr.comparisonVersion>1.0.2</clirr.comparisonVersion>
+    <clirr.comparisonVersion>1.0.3</clirr.comparisonVersion>
     <gcu.product>Cache</gcu.product>
   </properties>
 
@@ -66,7 +67,7 @@
     <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
-      <version>3.2.6</version>
+      <version>3.2.7</version>
       <scope>provided</scope>
     </dependency>
 
@@ -76,7 +77,7 @@
     <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
-      <version>2.6.8</version>
+      <version>2.6.9</version>
       <scope>compile</scope>
     </dependency>
 
@@ -85,7 +86,7 @@
     -->
     <dependency>
       <groupId>javax.transaction</groupId>
-      <artifactId>jta</artifactId>
+      <artifactId>transaction-api</artifactId>
       <version>1.1</version>
       <scope>provided</scope>
     </dependency>
@@ -97,6 +98,12 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Fix XSD of maven
Use mybatis-parent 22-SNAPSHOT
Change <name> to match <artifactId> so it works properly in myEclipse
imports and follows maven best practice.
Updated mybatis to 3.2.7
Change jta to transaction-api
Added slf4j-simple as test dependency to get rid of warnings during
maven build.
Updated clirr comparison version to match prior version
Updated ehcache core to 2.6.9
