### PR TITLE
Remove unneeded gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /.idea
 /.project
 /.settings
-/derby.log
 /ibderby
 /nb*
 /release.properties


### PR DESCRIPTION
derby.log was switched to be produced under target so no need to ignore
it now.
