### PR TITLE
Support for decorated Ehcache

### DIFF
--- a/src/main/java/org/mybatis/caches/ehcache/EhcacheCache.java
+++ b/src/main/java/org/mybatis/caches/ehcache/EhcacheCache.java
@@ -15,7 +15,6 @@
  */
 package org.mybatis.caches.ehcache;
 
-import net.sf.ehcache.Element;
 
 public class EhcacheCache extends AbstractEhcacheCache {
 
@@ -24,7 +23,7 @@ public class EhcacheCache extends AbstractEhcacheCache {
     if (!CACHE_MANAGER.cacheExists(id)) {
       CACHE_MANAGER.addCache(id);
     }
-    this.cache = CACHE_MANAGER.getCache(id);
+    this.cache = CACHE_MANAGER.getEhcache(id);
   }
 
 }


### PR DESCRIPTION
Method getEhcache() should be used instead of getCache() because it supports decorated caches.