### PR TITLE
Raise ehcache to 2.10.5 (using internal core), update maven wrapper, and remove versioneye

### DIFF
--- a/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/.mvn/wrapper/MavenWrapperDownloader.java
@@ -28,7 +28,7 @@ public class MavenWrapperDownloader {
      * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
      */
     private static final String DEFAULT_DOWNLOAD_URL =
-            "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.0/maven-wrapper-0.4.0.jar";
+            "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar";
 
     /**
      * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,3 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.3/apache-maven-3.5.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.0/maven-wrapper-0.4.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.4/apache-maven-3.5.4-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ MyBatis Ehcache Extension
 
 [![Build Status](https://travis-ci.org/mybatis/ehcache-cache.svg?branch=master)](https://travis-ci.org/mybatis/ehcache-cache)
 [![Coverage Status](https://coveralls.io/repos/mybatis/ehcache-cache/badge.svg?branch=master&service=github)](https://coveralls.io/github/mybatis/ehcache-cache?branch=master)
-[![Dependency Status](https://www.versioneye.com/user/projects/560f3b3b5a262f001a000a20/badge.svg?style=flat)](https://www.versioneye.com/user/projects/560f3b3b5a262f001a000a20)
 [![Maven central](https://maven-badges.herokuapp.com/maven-central/org.mybatis.caches/mybatis-ehcache/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.mybatis.caches/mybatis-ehcache)
 [![License](http://img.shields.io/:license-apache-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 

--- a/mvnw
+++ b/mvnw
@@ -212,7 +212,7 @@ else
     if [ "$MVNW_VERBOSE" = true ]; then
       echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
     fi
-    jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.0/maven-wrapper-0.4.0.jar"
+    jarUrl="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) jarUrl="$value"; break ;;
       esac

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -120,7 +120,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.0/maven-wrapper-0.4.0.jar"
+set DOWNLOAD_URL="https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/maven-wrapper-0.4.2.jar"
 FOR /F "tokens=1,2 delims==" %%A IN (%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties) DO (
 	IF "%%A"=="wrapperUrl" SET DOWNLOAD_URL=%%B 
 )

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2010-2017 the original author or authors.
+       Copyright 2010-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -78,9 +78,9 @@
      | compile dependencies
     -->
     <dependency>
-      <groupId>net.sf.ehcache</groupId>
+      <groupId>net.sf.ehcache.internal</groupId>
       <artifactId>ehcache-core</artifactId>
-      <version>2.6.11</version>
+      <version>2.10.5</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Not sure if we should make this provided scope but we should upgrade at least as internals on ehcache changed years ago and there is a vulnerability which resulted in 2.10.5 release (probably not in core though)